### PR TITLE
Remove nested sidebar logic

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -10,7 +10,7 @@
     <div class="usa-grid py1 sm-py2">
       <h4 class="my0">Sign up for our mailing list</h4>
       <div class="usa-width-one-whole md-flex items-center">
-        <p class="my0 mr1 regular">Receive occassional updates about our work and news about the plain language community.</p>
+        <p class="my0 md-mr1">Receive occassional updates about our work and news about the plain language community.</p>
         <a class="usa-button usa-button-primary-alt my0 mt1 mr0 md-mt0 nowrap" href="https://www.digitalgov.gov/communities/plain-language-community-of-practice/">Join the mailing list</a>
       </div>
     </div>
@@ -22,7 +22,7 @@
           The <a href="{{ "/about/" | relative_url }}">Plain Language Action and Information Network</a> develops and maintains the content of this site with support from the <a href="https://gsa.gov">General Services Administration</a>.
         </p>
         <p>
-          Help us improve this site on <a href="https://github.com/GSA/plainlanguage.gov"><img src="{{ "/assets/img/github.svg" | relative_url }}" alt="">GitHub</a>.
+          Help us improve this site on <a href="{{ site.repo }}"><img src="{{ "/assets/img/github.svg" | relative_url }}" alt="">GitHub</a>.
         </p>
       </div>
       <div class="usa-width-one-fourth">

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,43 +1,23 @@
-{% if page.sidenav %}
-  <ul class="usa-sidenav-list">
-    {% for link in include.links %}
-      {% assign _href = link.href %}
-      {% assign _current = false %}
-      {% if link.href == page.url or link.href == page.permalink %}
-        {% assign _current = true %}
+<ul class="usa-sidenav-list">
+  {% for link in include.links %}
+    {% assign _href = link.href %}
+    {% assign _current = false %}
+    {% if link.href == page.url or link.href == page.permalink %}
+      {% assign _current = true %}
+    {% endif %}
+    <li>
+      <a href="{% if link.external == true %}{{ link.href }}{% else %}{{ link.href | relative_url }}{% endif %}" class="{% if _current %}usa-current{% endif %} {% if page.url contains _href or page.permalink contains _href %}current-parent{% endif %}">
+        {{ link.text }}
+      </a>
+      {% if (_current or (page.url contains _href or page.permalink contains _href)) and link.subnav %}
+        <ul class="usa-sidenav-sub_list">
+          {% for sublink in link.subnav %}
+            <li>
+              <a href="{% if sublink.external == true %}{{ sublink.href }}{% else %}{{ sublink.href | relative_url }}{% endif %}" {% if page.url == sublink.href or page.permalink == sublink.href %}class="usa-current"{% endif %}>{{ sublink.text }}</a>
+            </li>
+          {% endfor %}
+        </ul>
       {% endif %}
-      <li>
-        <a href="{% if link.external == true %}{{ link.href }}{% else %}{{ link.href | relative_url }}{% endif %}" class="{% if _current %}usa-current{% endif %} {% if page.url contains _href or page.permalink contains _href %}current-parent{% endif %}">
-          {{ link.text }}
-        </a>
-        {% if (_current or (page.url contains _href or page.permalink contains _href)) and link.subnav %}
-          <ul class="usa-sidenav-sub_list">
-            {% for sublink in link.subnav %}
-              <li>
-                <a href="{% if sublink.external == true %}{{ sublink.href }}{% else %}{{ sublink.href | relative_url }}{% endif %}" {% if page.url == sublink.href or page.permalink == sublink.href %}class="usa-current"{% endif %}>{{ sublink.text }}</a>
-                {% if ((sublink.href == page.url or sublink.href == page.permalink) or (page.url contains sublink.href or page.permalink contains sublink.href)) and sublink.subnav %}
-                  <ul class="usa-sidenav-sub_list">
-                    {% for subsublink in sublink.subnav %}
-                      <li>
-                        <a href="{% if subsublink.external == true %}{{ subsublink.href }}{% else %}{{ subsublink.href | relative_url }}{% endif %}" {% if page.url == subsublink.href or page.permalink == subsublink.href %}class="usa-current"{% endif %}>{{ subsublink.text }}</a>
-                        {% if ((subsublink.href == page.url or subsublink.href == page.permalink) or (page.url contains subsublink.href or page.permalink contains subsublink.href)) and subsublink.subnav %}
-                          <ul class="usa-sidenav-sub_list">
-                            {% for subsubsublink in subsublink.subnav %}
-                              <li>
-                                <a href="{% if subsubsublink.external == true %}{{ subsubsublink.href }}{% else %}{{ subsubsublink.href | relative_url }}{% endif %}" {% if page.url == subsubsublink.href or page.permalink == subsubsublink.href %}class="usa-current"{% endif %}>{{ subsubsublink.text }}</a>
-                              </li>
-                            {% endfor %}
-                          </ul>
-                        {% endif %}
-                      </li>
-                    {% endfor %}
-                  </ul>
-                {% endif %}
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </li>
-    {% endfor %}
-  </ul>
-{% endif %}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
Remove the third and forth level of sidebar navigation that I originally added to temporarily accommodate the migrated content.