### PR TITLE
Use email address for contact links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Site settings
 title: plainlanguage.gov
 description: Resources to help federal employees deliver clear communications to the public.
+email: plainlanguage@gsa.gov
 
 # Using https://github.com/18F/uswds-jekyll
 theme: uswds-jekyll

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -36,7 +36,7 @@
       <div class="usa-width-one-fourth">
         <h3>Contact us</h3>
         <ul class="usa-unstyled-list">
-          <li><a href="mailto:plainlanguage@gsa.gov"><img src="{{ "/assets/img/envelope-o.svg" | relative_url }}" alt="">Email us</a></li>
+          <li><a href="mailto:{{ site.email }}"><img src="{{ "/assets/img/envelope-o.svg" | relative_url }}" alt="">Email us</a></li>
           <li><a href="https://www.facebook.com/plainlanguagegov-174397429237337/"><img src="{{ "/assets/img/facebook-f.svg" | relative_url }}" alt="">Facebook</a></li>
           <li><a href="https://twitter.com/govplainlang"><img src="{{ "/assets/img/twitter.svg" | relative_url }}" alt="">Twitter</a></li>
         </ul>

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -13,4 +13,4 @@ Were you looking for one of these pages?
 - [Training]({{ site.baseurl }}/training/)
 - [Resources]({{ site.baseurl }}/resources/)
 
-If you have other questions, please [contact us]({{ site.baseurl }}/contact/).
+If you have other questions, please [contact us](mailto:{{ site.email }}).

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -37,7 +37,7 @@ To promote plain language, we:
 
 We meet monthly to discuss plain language issues. Our meetings are open to all federal employees. [Join our listserv](https://www.digitalgov.gov/communities/plain-language-community-of-practice/) to learn about upcoming events.
 
-Please [contact us]({{ site.baseurl }}/contact/) if:
+Please [contact us](mailto:{{ site.email }}) if:
 
 - we can help your agency with plain language issues
 - you want us to present a half day training program at your agency

--- a/_pages/guidelines/index.md
+++ b/_pages/guidelines/index.md
@@ -20,4 +20,4 @@ We first developed these writing guidelines in the mid 1990s. We continue to rev
 
 ## Questions? Comments?
 
-If you have any feedback or questions about these guidelines, please [contact us]({{ site.baseurl }}/contact/). We also offer [free half-day training sessions for federal agencies]({{ site.baseurl }}/training/) in the Washington, DC area.
+If you have any feedback or questions about these guidelines, please [contact us](mailto:{{ site.email }}). We also offer [free half-day training sessions for federal agencies]({{ site.baseurl }}/training/) in the Washington, DC area.

--- a/_pages/law/requirements/agency-contacts.md
+++ b/_pages/law/requirements/agency-contacts.md
@@ -4,7 +4,7 @@ permalink: /law/requirements/agency-contacts/
 sidenav: law
 ---
 
-[The Act](https://www.gpo.gov/fdsys/pkg/PLAW-111publ274/content-detail.html) was signed in October 2010, but some federal agencies have been promoting the use of plain language for years. (If you don't see your agency's program listed here, [contact us]({{ site.baseurl }}/contact/) so we can include it.)
+[The Act](https://www.gpo.gov/fdsys/pkg/PLAW-111publ274/content-detail.html) was signed in October 2010, but some federal agencies have been promoting the use of plain language for years. (If you don't see your agency's program listed here, [contact us](mailto:{{ site.email }}) so we can include it.)
 
 {% assign contacts = (site.data.contacts | sort: 'department') %}
 {% for contact in contacts %}

--- a/_pages/law/requirements/index.md
+++ b/_pages/law/requirements/index.md
@@ -34,6 +34,6 @@ Use plain language in any document that:
 
 ## Questions?
 
-- [Contact us]({{ site.baseurl }}/contact/) or [subscribe to our mailing list](https://www.digitalgov.gov/communities/plain-language-community-of-practice/) for the latest updates.
+- [Contact us](mailto:{{ site.email }}) or [subscribe to our mailing list](https://www.digitalgov.gov/communities/plain-language-community-of-practice/) for the latest updates.
 
 - Sign up for one of our [training sessions]({{ site.baseurl }}/training/).

--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -54,12 +54,8 @@ Users of this website may send the Plain Language Action and Information Network
 
 ## Children and privacy
 
-We do not have information specifically for children on our website. The [Children’s Online Privacy Protection Act](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/childrens-online-privacy-protection-rule) governs information gathered online from or about children under the age of 13. This site is not intended to solicit or collection information of any kind from children under age 13. If you believe that we have received information from a child under age 13, please contact us at [plainlanguage@gsa.gov](mailto:plainlanguage@gsa.gov).
+We do not have information specifically for children on our website. The [Children’s Online Privacy Protection Act](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/childrens-online-privacy-protection-rule) governs information gathered online from or about children under the age of 13. This site is not intended to solicit or collection information of any kind from children under age 13. If you believe that we have received information from a child under age 13, please contact us at [{{ site.email }}](mailto:{{ site.email }}).
 
 ## Questions about privacy
 
-If you have questions about this privacy policy, please email us at [plainlanguage@gsa.gov](mailto:plainlanguage@gsa.gov).
-
-
-
-
+If you have questions about this privacy policy, please email us at [{{ site.email }}](mailto:{{ site.email }}).

--- a/_pages/resources/guides/plain-language-guidance-and-manuals.md
+++ b/_pages/resources/guides/plain-language-guidance-and-manuals.md
@@ -4,7 +4,7 @@ permalink: /resources/guides/plain-language-guidance-and-manuals/
 sidenav: resources
 ---
 
-Over the last few years we've seen an explosion in the numbers and types of documents presenting plain-language guidelines. We have room for only a few of the best here. Because many of our readers are federal employees, we've focused on materials developed by the federal government. If you know of something you think we should include, [contact us](#).
+Over the last few years we've seen an explosion in the numbers and types of documents presenting plain-language guidelines. We have room for only a few of the best here. Because many of our readers are federal employees, we've focused on materials developed by the federal government. If you know of something you think we should include, [contact us](mailto:{{ site.email }}).
 
 ## General guidance and manuals
 

--- a/_pages/resources/index.md
+++ b/_pages/resources/index.md
@@ -20,4 +20,4 @@ Are you trying to persuade your colleagues or your boss that it's a good idea to
 
 [Materials for Trainers](for_trainers/index.cfm)
 
-Do you need to present a training class on plain language? These materials will help you. Or we may be able to come to your agency and present a half-day program free. You must pay any travel expenses. If you're interested, [contact us](../site/contactus.cfm?subject=training).
+Do you need to present a training class on plain language? These materials will help you. Or we may be able to come to your agency and present a half-day program free. You must pay any travel expenses. If you're interested, [contact us](mailto:{{ site.email }}).

--- a/_pages/training/for-trainers/index.md
+++ b/_pages/training/for-trainers/index.md
@@ -40,4 +40,4 @@ We've included other resources that can help you present training in plain langu
 
 ## Questions?
 
-If you have any questions or need more help, [contact us]({{ site.baseurl }}/contact/).
+If you have any questions or need more help, [contact us](mailto:{{ site.email }}).

--- a/_pages/training/for-trainers/tips-for-starting-plain-language-program.md
+++ b/_pages/training/for-trainers/tips-for-starting-plain-language-program.md
@@ -10,7 +10,7 @@ Starting a plain-language program can be challenging. But like most challenges, 
 
 [The Plain Writing Act of 2010](http://frwebgate.access.gpo.gov/cgi-bin/getdoc.cgi?dbname=111_cong_bills&docid=f:h946enr.txt.pdf) requires agencies to train their staff in plain language. PLAIN offers free consultation to federal agencies on how to start an internal agency plain language program. We have previously worked with the National Institutes of Health, U.S Citizenship and Immigration Services, and Veterans Benefits Administration (to name a few). These agencies now have self-run, thriving plain language programs.
 
-Please [contact us]({{ site.baseurl }}/contact/) to find out more about how we can help your agency clearly communicate with the public.
+Please [contact us](mailto:{{ site.email }}) to find out more about how we can help your agency clearly communicate with the public.
 
 ## Set SMART goals
 

--- a/_pages/training/introductory-classes.md
+++ b/_pages/training/introductory-classes.md
@@ -31,7 +31,7 @@ For training outside the DC area, you must pay the trainer's expenses. We'll com
 
 ## Schedule a class
 
-Please [contact us]({{ site.baseurl }}/contact/) to request training at least 3 months before you want to schedule the class. Let us know:
+Please [contact us](mailto:{{ site.email }}) to request training at least 3 months before you want to schedule the class. Let us know:
 
 - Which federal agency you work for
 - Which classes you'd prefer

--- a/_pages/training/online-training.md
+++ b/_pages/training/online-training.md
@@ -16,4 +16,4 @@ Plain-language training is available in many forms — ranging from traditional 
 
 - The government of Mexico kicked off a program in 2004 encouraging plain language in government writing. You can download this compressed file of [the materials](lenguaje.zip) they prepared for the participants. This material is in Spanish.
 
-If you know of any training resources that we've overlooked, please [contact us]({{ site.baseurl }}/contact/).
+If you know of any training resources that we've overlooked, please [contact us](mailto:{{ site.email }}).


### PR DESCRIPTION
Use `mailto:` link in lieu of a contact page.