### PR TITLE
Generate resource lists from data file

### DIFF
--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -1,0 +1,48 @@
+# Sample entry:
+#  - title: Article title goes here
+#    href: /path/to/resource/ or http://external.link/to/resource
+#    external: true  #Optional
+#    author: Author's name goes here #Optional
+#    pub_date: 2010-10-31  #Optional, must follow specified date format
+#    description: >- #Optional
+#      Speech given to 600 high-level Mexican public servants at the launching
+#      plain language conference Lenguaje ciudadano on the 5th of October 2004.
+
+articles:
+  - title: Arguments in favor of plain language
+    href: /resources/articles/arguments-in-favor-of-plain-language/
+  - title: Mary Dash’s writing tips
+    href: /resources/articles/mary-dashs-writing-tips/
+  - title: "Plain language: beyond a movement"
+    href: /resources/articles/plain-language-beyond-a-movement/
+  - title: Plain language in spoken communication
+    href: /resources/articles/plain-language-in-spoken-communication/
+  - title: Plain language in Sweden, the results after 30 years
+    href: /resources/articles/plain-language-in-sweden-the-results-after-30-years/
+    author: Barbro Ehrenberg-Sundin, Senior Adviser, Ministry of Justice, Sweden
+    pub_date: 2004-10-05
+    description: >-
+      Speech given to 600 high-level Mexican public servants at the launching plain language
+      conference Lenguaje ciudadano on the 5th of October 2004.
+  - title: "Plain language: its effect on organizational performance"
+    href: /resources/articles/plain-language-its-effect-on-organizational-performance/
+  - title: "Plain language: the bottom line"
+    href: /resources/articles/plain-language-the-bottom-line/
+  - title: “Plain talk” in Washington
+    href: /resources/articles/plain-talk-in-washington/
+  - title: Politics and the English language
+    href: /resources/articles/politics-and-the-english-language/
+  - title: Pretentious language wastes time
+    href: /resources/articles/pretentious-language-wastes-time/
+  - title: Revisiting plain language
+    href: /resources/articles/revisiting-plain-language/
+  - title: Scientists need plain language
+    href: /resources/articles/scientists-need-plain-language/
+  - title: Simple words work best
+    href: /resources/articles/simple-words-work-best/
+  - title: The arguments against plain language have been refuted
+    href: /resources/articles/the-arguments-against-plain-language-have-been-refuted/
+  - title: The elements of plain language
+    href: /resources/articles/the-elements-of-plain-language/
+  - title: The hidden costs of complex language
+    href: /resources/articles/the-hidden-costs-of-complex-language/

--- a/_includes/resources.html
+++ b/_includes/resources.html
@@ -1,0 +1,15 @@
+{% assign resources = site.data.resources[page.resources] %}
+<ul>
+{% for resource in resources %}
+  <li>
+    <a href="{% if resource.external == true %}{{ resource.href }}{% else %}{{ resource.href | relative_url }}{% endif %}" class="bold">{{ resource.title }}</a>
+    {% if resource.author or resource.pub_date %}
+    <ul class="usa-unstyled-list h5">
+      <li><strong>Author:</strong> {{ resource.author }}</li>
+      <li><strong>Published:</strong> {{ resource.pub_date }}</li>
+    </ul>
+    {% endif %}
+    {% if resource.description %}<p class="h5">{{ resource.description }}</p>{% endif %}
+  </li>
+{% endfor %}
+</ul>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -23,6 +23,10 @@ main:
 
   {{ content }}
 
+  {% if page.resources %}
+    {% include resources.html %}
+  {% endif %}
+
   {% if page.sources %}
     {% include sources.html %}
   {% endif %}

--- a/_pages/resources/articles/index.md
+++ b/_pages/resources/articles/index.md
@@ -2,5 +2,5 @@
 title: Articles
 permalink: /resources/articles/
 sidenav: resources
-layout: list
+resources: articles
 ---


### PR DESCRIPTION
This uses a similar approach to our main navigation data file to generate a list of resources that can either be internal pages or external links. You can also optionally include values for `author`, `pub_date`, and `description` as well.

To add this list to a page, add `resources: articles` to the front matter of the page, swapping `articles` with the corresponding name of the group within the `resources.yml` data file.

I just set up articles to start with, but if you are 👍  with this approach I can convert the other sections as well. Also... the way the author, date, and description are displayed within the generated list needs some love, but I can clean that up in another PR.