### PR TITLE
Add robots meta to non production sites

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -3,6 +3,9 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
   <head>
+    {% unless site.env == "production" %}
+      <meta name="robots" content="noindex, nofollow">
+    {% endunless %}
     {% include meta.html %}
     {% include styles.html %}
     <script>


### PR DESCRIPTION
This will make it so the `demo` site (https://demo.plainlanguage.gov) is not indexed by search engines.