### PR TITLE
Tweak example styles

### DIFF
--- a/_pages/examples/before-and-after/ambiguity.md
+++ b/_pages/examples/before-and-after/ambiguity.md
@@ -10,17 +10,25 @@ Here are some examples of how using plain language can help clear up clarity pro
 
 ## Example 1
 
-Before | After
---- | ---
-Right of use means any authorization issued under this part that allows use of Outer Continental Shelf lands. | Right of use means any authorization under this part to use Outer Continental Shelf lands.
-{:.example-table}
+* #### Before
+
+  Right of use means any authorization issued under this part that allows use of Outer Continental Shelf lands.
+
+* #### After
+
+  Right of use means any authorization under this part to use Outer Continental Shelf lands.
+{: .example-side-by-side}
 
 ## Example 2
 
-Before | After
---- | ---
-This rule proposes the Spring/Summer subsistence harvest regulations in Alaska for migratory birds that expire on August 31, 2003. | This rule proposes the Spring/Summer subsistence harvest regulations for migratory birds in Alaska. The regulations will expire on August 31, 2003.
-{:.example-table}
+* #### Before
+
+  This rule proposes the Spring/Summer subsistence harvest regulations in Alaska for migratory birds that expire on August 31, 2003.
+
+* #### After
+
+  This rule proposes the Spring/Summer subsistence harvest regulations for migratory birds in Alaska. The regulations will expire on August 31, 2003.
+{: .example-side-by-side}
 
 ## Example 3
 

--- a/_pages/examples/before-and-after/wordiness.md
+++ b/_pages/examples/before-and-after/wordiness.md
@@ -10,24 +10,36 @@ Here are some examples of how using plain language can help you say what you mea
 
 ## Example 1
 
-Before | After
---- | ---
-If the location of the land is in a state other than the state in which the tribe’s reservation is located, the tribe’s justification of anticipated benefits from the acquisition will be subject to greater scrutiny. | If the land is in a different State than the tribe's reservation, we will scrutinize the tribe's justification of anticipated benefits more thoroughly.
-{:.example-table}
+* #### Before
+
+  If the location of the land is in a state other than the state in which the tribe’s reservation is located, the tribe’s justification of anticipated benefits from the acquisition will be subject to greater scrutiny.
+
+* #### After
+
+  If the land is in a different State than the tribe's reservation, we will scrutinize the tribe's justification of anticipated benefits more thoroughly.
+{: .example-side-by-side}
 
 ## Example 2
 
-Before | After
---- | ---
-When the process of freeing a vehicle that has been stuck results in ruts or holes, the operator will fill the rut or hole created by such activity before removing the vehicle from the immediate area. | If you make a hole while freeing a stuck vehicle, you must fill the hole before you drive away.
-{:.example-table}
+* #### Before
+
+  When the process of freeing a vehicle that has been stuck results in ruts or holes, the operator will fill the rut or hole created by such activity before removing the vehicle from the immediate area.
+
+* #### After
+
+  If you make a hole while freeing a stuck vehicle, you must fill the hole before you drive away.
+{: .example-side-by-side}
 
 ## Example 3
 
-Before | After
---- | ---
-Under 25 CFR §1.4(b), the Secretary of the Interior may in specific cases or in specific geographic areas, adopt or make applicable to off-reservation Indian lands all or any part of such laws, ordinances, codes, resolutions, rules or other regulations of the State and political subdivisions in which the land is located as the Secretary shall determine to be in the best interest of the Indian owner or owners in achieving the highest and best use of such property. | Section 1.4(b) of 25 CFR allows us to make State or local laws or regulations apply to your off-reservation lands. We will do this only if we find that it will help you to achieve the highest and best use of your lands.
-{:.example-table}
+* #### Before
+
+  Under 25 CFR §1.4(b), the Secretary of the Interior may in specific cases or in specific geographic areas, adopt or make applicable to off-reservation Indian lands all or any part of such laws, ordinances, codes, resolutions, rules or other regulations of the State and political subdivisions in which the land is located as the Secretary shall determine to be in the best interest of the Indian owner or owners in achieving the highest and best use of such property.
+
+* #### After
+
+  Section 1.4(b) of 25 CFR allows us to make State or local laws or regulations apply to your off-reservation lands. We will do this only if we find that it will help you to achieve the highest and best use of your lands.
+{: .example-side-by-side}
 
 ## Example 4
 

--- a/_sass/components/_examples.scss
+++ b/_sass/components/_examples.scss
@@ -177,6 +177,22 @@ $example-good-color: #0d8259;
     }
   }
 
+  table {
+    margin: 0;
+
+    thead th {
+      background-color: transparent;
+      border-top: 0;
+    }
+
+    th,
+    td {
+      background-color: transparent;
+      border-left: 0;
+      border-right: 0;
+    }
+  }
+
   &::before,
   &::after {
     content: ' ';

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -20,7 +20,7 @@
   }
 }
 
-.usa-layout-docs-main_content {
+.usa-layout-docs-main_content { // scss-lint:disable SelectorFormat
   a[href*="//"]:not([href*="plainlangugage.gov"])::after { // scss-lint:disable SelectorFormat, QualifyingElement
     background-image: url('../img/icons/primary/external-link.svg');
     background-position: center;
@@ -35,7 +35,7 @@
     width: $spacing-md-small;
   }
 
-  table {
+  > table {
     th,
     td {
       border-color: $color-tan-dark;


### PR DESCRIPTION
This fixes table styles when they are within an example container.

Before:
![screen shot 2017-11-15 at 4 30 56 pm](https://user-images.githubusercontent.com/1178494/32861220-1269fb4e-ca22-11e7-98c4-66d2bac644fd.png)

After:
![screen shot 2017-11-15 at 4 31 03 pm](https://user-images.githubusercontent.com/1178494/32861223-1649b25e-ca22-11e7-9d83-550799b16055.png)

It also standardizes the type of example style being used on a few pages, switching them all to be side by side examples instead of using the table based format.
