### PR TITLE
Update Github link to reflect current page in repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,10 @@ email: info@plainlanguage.gov
 image: /assets/img/twitter_profile.png
 facebook: https://www.facebook.com/plainlanguagegov-174397429237337/
 twitter: https://twitter.com/govplainlang/
-repo: https://github.com/GSA/plainlanguage.gov
+github:
+  organization: GSA
+  repository: plainlanguage.gov
+  default_branch: master
 
 sitewide_notification:
   display: false

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -17,7 +17,7 @@
           The <a href="{{ "/about/" | relative_url }}">Plain Language Action and Information Network</a> develops and maintains the content of this site with support from the <a href="https://www.gsa.gov/node/87579">General Services Administration</a>.
         </p>
         <p>
-          Help us improve this site on <a href="{{ site.repo }}"><i class="icon icon-github" aria-hidden="true"></i>GitHub</a>.
+          Help us improve this site on <a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/{{ page.path }}"><i class="icon icon-github mr1" aria-hidden="true"></i>GitHub</a>.
         </p>
       </div>
       <div class="usa-width-one-fourth md-mb3">


### PR DESCRIPTION
To help contributors navigate to the correct page within the Github repo.