### PR TITLE
Bring skipnav link to foreground

### DIFF
--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -2,6 +2,10 @@
   border-color: $border-color;
 }
 
+.usa-skipnav {
+  z-index: 10000;
+}
+
 .sticky-nav .usa-header {
   position: -webkit-sticky; // scss-lint:disable VendorPrefix
   position: sticky;


### PR DESCRIPTION
The skipnav link is being obscured by the top USA banner.

From this:
<img width="377" alt="screen shot 2017-11-30 at 9 34 18 am" src="https://user-images.githubusercontent.com/1178494/33436530-57483694-d5b3-11e7-848b-2d5d0c51f303.png">

To this:
<img width="352" alt="screen shot 2017-11-30 at 9 34 47 am" src="https://user-images.githubusercontent.com/1178494/33436539-5eef685e-d5b3-11e7-9185-a9f9d0fa5e5c.png">
