### PR TITLE
Set height on sticky sidenav

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,13 +1,13 @@
-<h4 class="caps mt5 mb3 inline-block">Downloads</h4>
+<h4 class="caps mt5 mb3">Downloads</h4>
 <div class="guidelines clearfix">
   <img src="{{ site.baseurl }}/assets/img/guidelines-cover.png" class="left mr3" alt="">
   <div class="overflow-hidden">
-    <h5 class="h4 mt0 inline-block">Federal Plain Language Guidelines</h5>
+    <h5 class="h4 mt0">Federal Plain Language Guidelines</h5>
     <p class="usa-text-small mb1">
       Published: March 2011<br>
       Revised: May 2011
     </p>
-    <h6 class="my0 inline-block">Download:</h6>
+    <h6 class="my0">Download:</h6>
     <ul class="usa-unstyled-list">
       <li class="inline-block"><a href="{{ site.baseurl }}/media/FederalPLGuidelines.pdf" class="usa-label usa-text-small white bg-blue sans-serif text-decoration-none">PDF</a></li>
       <li class="inline-block"><a href="{{ site.baseurl }}/media/FederalPLGuidelines.docx" class="usa-label usa-text-small white bg-blue sans-serif text-decoration-none">Word</a></li>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,4 +1,4 @@
-<h4 class="caps inline-block">In this section</h4>
+<h4 class="caps">In this section</h4>
 
 <ul class="usa-sidenav-list">
   {% for link in include.links %}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,11 @@
+import $ from 'jquery';
 import Stickyfill from 'stickyfilljs';
 
 var elements = document.getElementsByClassName('sticky');
 Stickyfill.add(elements);
+
+var navHeight = function () {
+  $('.usa-layout-docs-sidenav').css('height', $('.usa-layout-docs-sidenav').height());
+};
+
+navHeight();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-preset-es2015": "^6.14.0",
     "basscss-sass": "^4.0.0",
+    "jquery": "^3.2.1",
     "stickyfilljs": "^2.0.2",
     "webpack": "^1.13.2"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,13 @@ module.exports = {
     ]
   },
 
+  plugins: [
+    new webpack.ProvidePlugin({
+      $: 'jquery',
+      jQuery: 'jquery'
+    })
+  ],
+
   resolve: {
     extensions: ['', '.js']
   }


### PR DESCRIPTION
There has been a lingering bug with the side navigation where it jumps a pixel or two when hovering over links. This sets an explicit height on the side navigation container rather than leaving it up to the browser to interpret - which I believe will resolve the problem.