### PR TITLE
remove double 'the'

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -2,7 +2,7 @@
   date: 2018-03-14
   link: https://www.digitalgov.gov/event/infographics-plain-language-considerations/
   description: |-
-    Join the the Plain Language Community of Practice for an hour-long conversation about what makes a good plain language infographic – 
+    Join the Plain Language Community of Practice for an hour-long conversation about what makes a good plain language infographic – 
     one that anyone can understand.
 
     We’ll cover:


### PR DESCRIPTION
Easy enough. In the events page, change _Join the the Plain Language Community_ to  _Join the Plain Language Community_.