### PR TITLE
fix event syntax

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -6,8 +6,8 @@
     and what agencies can do to get top grades.
 
     The annual Federal Report Card is a snapshot of how well the federal government is following the 2010 Plain Writing Act. 
-This year, the Center is excited to celebrate the 10th anniversary of the Plain Writing Act, including everything federal agencies 
-have done to give the public the clear communication it needs.
+    This year, the Center is excited to celebrate the 10th anniversary of the Plain Writing Act, including everything federal agencies 
+    have done to give the public the clear communication it needs.  
 
     [Register for the July 15 meeting »](https://digital.gov/event/2020/07/15/federal-report-card-update/)
 


### PR DESCRIPTION
Changes made:
- add tab spaces to line 9 and 10 to correct the syntax
- add 2 spaces at the end of line 10 to force the Register link down to the next line

<img width="953" alt="Screen Shot 2020-06-24 at 8 34 20 AM" src="https://user-images.githubusercontent.com/2197515/85557505-d1d16f00-b5f5-11ea-92de-087ca5d11b78.png">

[Preview on federalist](https://federalist-dad55c1b-07c6-4c7e-89da-5aff1f9335fd.app.cloud.gov/preview/gsa/plainlanguage.gov/sc_fix-event/)