### PR TITLE
Add link to How To Write Clearly by the EC

### DIFF
--- a/_pages/resources/books/index.md
+++ b/_pages/resources/books/index.md
@@ -22,6 +22,8 @@ There are many important books about plain language. Most of them are not availa
 
 - _Garner's Modern English Usage_, Bryan Garner. More information than you will ever need to know about lexicography and the nuances of the English language.
 
+- [How to Write Clearly](https://op.europa.eu/s/n9L3), European Commision.  Guidelines to write clear documents.
+
 - _How to Write Short_, Roy Peter Clark.
 
 - _If I Understood You, Would I Have This Look on My Face? Relating to and Communicating with Others, from the Boardroom to the Bedroom_, Alan Alda.


### PR DESCRIPTION
European staff have to write many different types of documents.  Whatever the type--legislation, a technical report, minutes, a press release or speech--clear documents will be more effective, and more easily and quickly understood.

Good reasons to write clearly include:
* to work more effectively together
* to reduce unnecessary correspondence
* to build goodwill