### PR TITLE
Fix grammar mistake

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -70,7 +70,7 @@ redirect_from:
   <div class="usa-grid">
     <h2 class="mt0">About us</h2>
     <div class="usa-width-two-thirds md-pr5">
-    <p class="usa-font-lead">The Plain Language Action and Information Network (PLAIN) is a community of federal employees dedicated to the idea that citizens deserve clear communications from government. We believe that using plain language saves federal agencies time and money and provides better service to the American public.</p>
+    <p class="usa-font-lead">The Plain Language Action and Information Network (PLAIN) is a community of federal employees dedicated to the idea that citizens deserve clear communication from government. We believe that using plain language saves federal agencies time and money and provides better service to the American public.</p>
     </div>
     <div class="usa-width-one-third">
       <h3>Subscribe to our mailing list</h3>


### PR DESCRIPTION
A seemingly small and common mistake, but the word here should be "communication" and not "communications". While it might not seem like a big deal, this mistake drives communication professionals nuts.

Explanations:
https://www.linkedin.com/pulse/why-communication-communications-subhamoy-das/
https://www.mastersincommunications.com/faqs/communication-vs-communications#:~:text=Put%20simply%2C%20communication%20is%20the,which%20those%20messages%20get%20shared.
https://communication.cals.cornell.edu/about-us/why-communication-and-not-communications/
https://www.csusm.edu/communication/major_differences.html