### PR TITLE
Update to latest jquery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2317,9 +2317,9 @@
       }
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-preset-es2015": "^6.14.0",
     "basscss-sass": "^4.0.0",
-    "jquery": "^3.5.0",
+    "jquery": "^3.6.0",
     "pa11y-ci": "^2.3.0",
     "stickyfilljs": "^2.0.2",
     "webpack": "^1.13.2"


### PR DESCRIPTION
Updates jQuery from `3.5.0` to the latest current version, `3.6.0`
[Preview](https://federalist-dad55c1b-07c6-4c7e-89da-5aff1f9335fd.app.cloud.gov/preview/gsa/plainlanguage.gov/dw-update-jquery/) → 