### PR TITLE
Update link name to match page name

### DIFF
--- a/_pages/guidelines/words/avoid-jargon.md
+++ b/_pages/guidelines/words/avoid-jargon.md
@@ -44,7 +44,7 @@ The patient is being given positive-pressure ventilatory support. | The patient 
 Most refractory coatings to date exhibit a lack of reliability when subject to the impingement of entrained particulate matter in the propellant stream under extended firing durations. | The exhaust gas eventually damages the coating of most existing ceramics.
 {:.example-table}
 
-When you have no way to express an idea except to use technical language, make sure to define your terms. However, it's best to keep definitions to a minimum. Remember to write to communicate, not to impress. If you do that, you should naturally use less jargon. For more on definitions, see [Dealing with definitions]({{ site.baseurl }}{% link _pages/guidelines/words/minimize-definitions.md %}).
+When you have no way to express an idea except to use technical language, make sure to define your terms. However, it's best to keep definitions to a minimum. Remember to write to communicate, not to impress. If you do that, you should naturally use less jargon. For more on definitions, see [Minimize definitions]({{ site.baseurl }}{% link _pages/guidelines/words/minimize-definitions.md %}).
 
 ## Legal language
 


### PR DESCRIPTION
## Changes:

- Update link name to match the page name

## Context:

This link points to a page called "Minimize definitions". I think it makes sense to use the page name in the link.