### PR TITLE
Fix markdown in technical-terms-in-plain-english.md

### DIFF
--- a/_pages/resources/humor/technical-terms-in-plain-english.md
+++ b/_pages/resources/humor/technical-terms-in-plain-english.md
@@ -44,7 +44,9 @@ It is so wrapped up in red tape that the situation is about hopeless.
 
 10\. WE WILL LOOK INTO IT
 
-Forget it! We have enough problems for now. | 11\. PLEASE NOTE AND INITIAL
+Forget it! We have enough problems for now.
+
+11\. PLEASE NOTE AND INITIAL
 
 Let's spread the responsibility for the mistake.
 


### PR DESCRIPTION
The markdown in technical-terms-in-plain-english.md contains a stray `|`, which causes a table to be incorrectly created.  Removal fixes this problem.

(It does not escape me that this commit message is using the passive voice; hardly recommended plain language.)